### PR TITLE
⚠️ test: react-simple-typewriter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "next": "14.2.7",
         "react": "^18",
         "react-dom": "^18",
+        "react-simple-typewriter": "^5.0.1",
         "tailwindcss-animated": "^1.1.2"
       },
       "devDependencies": {
@@ -3817,6 +3818,18 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true
+    },
+    "node_modules/react-simple-typewriter": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/react-simple-typewriter/-/react-simple-typewriter-5.0.1.tgz",
+      "integrity": "sha512-vA5HkABwJKL/DJ4RshSlY/igdr+FiVY4MLsSQYJX6FZG/f1/VwN4y1i3mPXRyfaswrvI8xii1kOVe1dYtO2Row==",
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
+      }
     },
     "node_modules/read-cache": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "next": "14.2.7",
     "react": "^18",
     "react-dom": "^18",
+    "react-simple-typewriter": "^5.0.1",
     "tailwindcss-animated": "^1.1.2"
   },
   "devDependencies": {

--- a/src/components/single-use/Header.tsx
+++ b/src/components/single-use/Header.tsx
@@ -1,16 +1,14 @@
-import React from "react";
-
 export default function Header() {
   return (
-    <div>
+    <div className="select-none">
       {/* Titulo */}
       <h1 className="animate-flip-down text-5xl font-black animate-delay-[1500ms] animate-duration-[1200ms] animate-once">
-        leo<span className="text-violet-800">.dev()</span>
+        azael<span className="text-violet-800">.dev()</span>
       </h1>
 
       {/* Nombre */}
       <h4 className="mt-2 animate-fade-right text-2xl font-medium text-violet-800 animate-delay-[2400ms] animate-duration-1000 animate-once">
-        Leonardo Flores
+        Leonardo Azael
       </h4>
 
       {/* breve descripcion */}


### PR DESCRIPTION
Se importa la biblioteca de `react-simple-typewriter` para poder hacer el efecto de escribir texto.

Se hacen cambios en el Header para que el usuario no pueda seleccionar el texto y se cambia el contenido del Titulo y de mi nombre.